### PR TITLE
Minimal set of i386 packages to build on Travis VM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 before_install:
   # Install base Android SDK
   - sudo apt-get update -qq
-  - if [ `uname -m` = x86_64 ]; then sudo apt-get install -qq libc6:i386 libgcc1:i386 gcc-4.6-base:i386 libstdc++5:i386 libstdc++6:i386 lib32z1 libreadline6-dev:i386 libncurses5-dev:i386; fi
+  - if [ `uname -m` = x86_64 ]; then sudo apt-get install -qq libstdc++6:i386 lib32z1; fi
   - wget -O android-sdk.tgz http://dl.google.com/android/android-sdk_r22.0.4-linux.tgz
   - tar xzf android-sdk.tgz
   - export ANDROID_HOME=$PWD/android-sdk-linux


### PR DESCRIPTION
With brute force testing "technique", I end up with only 2 extra i386 packages to install, because:
- libc6, libgcc1 and gcc-4.6-base are dependencies of libstdc++6 package
- libstdc++5, libreadline6-dev and libncurses5-dev are not required (at least by this Android project)

**Question in relation to About travis-ci/travis-cookbooks/pull/153**: Do you think we can use the same package list or other Android projects may (often) require more preinstalled libraries by default ???
